### PR TITLE
feat(deploy): Kaiforge Lite CapRover deploy on main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,60 @@
+name: Deploy Kaiforge Lite
+
+on:
+  push:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: devxialabs/kaiforge-lite
+
+jobs:
+  build:
+    name: Build & Push Lite Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to CapRover (kaiforge-lite)
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Install CapRover CLI
+        run: npm install -g caprover
+
+      - name: Deploy
+        env:
+          CAPROVER_URL: ${{ secrets.CAPROVER_URL }}
+          APP_TOKEN: ${{ secrets.CAPROVER_APP_TOKEN_LITE }}
+          IMAGE_NAME: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+        run: |
+          caprover deploy \
+            --caproverUrl "$CAPROVER_URL" \
+            --appToken "$APP_TOKEN" \
+            --imageName "$IMAGE_NAME" \
+            --appName "kaiforge-lite"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Install dependencies
-FROM node:20-alpine AS deps
+FROM node:22-alpine AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 COPY package.json package-lock.json* yarn.lock* pnpm-lock.yaml* ./
@@ -10,22 +10,22 @@ RUN \
   else npm i; \
   fi
 
-# Stage 2: Build the application
-FROM node:20-alpine AS builder
+# Stage 2: Build the application (Next.js standalone output)
+FROM node:22-alpine AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build
 
-# Stage 3: Production runner
-FROM node:20-alpine AS runner
+# Stage 3: Production runner (Node server)
+FROM node:22-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
+RUN addgroup --system --gid 1001 nodejs \
+ && adduser --system --uid 1001 nextjs
 
 COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./


### PR DESCRIPTION
This PR updates Dockerfile to Node 22 and adds CI to build/push GHCR image and deploy to CapRover app kaiforge-lite on pushes to main.\n\nImage: ghcr.io/devxialabs/kaiforge-lite:latest\nApp: kaiforge-lite (lite.kaiforge.dev)\n\nSecrets needed:\n- CAPROVER_URL\n- CAPROVER_APP_TOKEN_LITE\n\nNext.js uses output: 'standalone' → served with node server.js.\n